### PR TITLE
Add model cards

### DIFF
--- a/california-housing/deployment/model_card.md
+++ b/california-housing/deployment/model_card.md
@@ -1,0 +1,27 @@
+## Description
+
+Predict house prices in California.
+
+The target variable is the median house value for California districts, expressed in hundreds of thousands of dollars ($100,000)
+
+This model was trained on the [California Housing dataset](https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html). Prices are predicted based on these features: median income, housing median age, total rooms, total bedrooms, population, households, latitude, and longitude.
+
+## Example Payload
+
+Here is an example payload you can use to test model inference.
+
+```json
+{
+    "inputs": [
+        {
+            "name": "input-0",
+            "shape": [1],
+            "datatype": "BYTES",
+            "parameters": null,
+            "data": [
+                [1.6812, 25.0, 4.1922, 1.0223, 1392.0, 3.8774, 36.06, -119.01]
+            ]
+        }
+    ]
+}
+```

--- a/iris-classification/deployment/model_card.md
+++ b/iris-classification/deployment/model_card.md
@@ -1,0 +1,38 @@
+## Description
+
+Classify different iris flowers based on their measurements.
+
+This model was trained on the classic Iris classification dataset. 
+
+Iris class is predicted based on these feaures:
+
+- Sepal length in cm
+- Sepal width in cm
+- Petal length in cm
+- Petal width in cm
+
+Output Iris class:
+
+1. Iris-Setosa
+2. Iris-Versicolour
+3. Iris-Virginica
+
+## Example Payload
+
+Here is an example payload you can use to test model inference.
+
+```json
+{
+    "inputs": [
+        {
+            "name": "input-0",
+            "shape": [1],
+            "datatype": "BYTES",
+            "parameters": null,
+            "data": [
+                [6.1, 2.8, 4.7, 1.2]
+            ]
+        }
+    ]
+}
+```

--- a/translate-dyu-fr-hugging-face/deployment/model_card.md
+++ b/translate-dyu-fr-hugging-face/deployment/model_card.md
@@ -1,0 +1,27 @@
+## Description
+
+An example of a machine translation model that translates Dyula to French using a pre-trained `t5-small` model form Hugging Face.
+
+This following example was trained on a Dyula-French translation datset that was kindly created by [data354](https://data354.com/en/).
+
+> This is not a production-ready model since it hasn't been trained for many epochs. It is for illustration purposes only.
+
+## Example Payload
+
+Here is an example payload you can use to test model inference.
+
+```json
+{
+    "inputs": [
+        {
+            "name": "input-0",
+            "shape": [1],
+            "datatype": "BYTES",
+            "parameters": null,
+            "data": [
+                "i tɔgɔ bi cogodɔ"
+            ]
+        }
+    ]
+}
+```

--- a/translate-dyu-fr-joyenmt/deployment/model_card.md
+++ b/translate-dyu-fr-joyenmt/deployment/model_card.md
@@ -1,0 +1,27 @@
+## Description
+
+An example of a machine translation model that translates Dyula to French using the [JoeyNMT framework](https://github.com/joeynmt/joeynmt).
+
+This following example is based on [this Github repo](https://github.com/data354/koumakanMT-challenge) that was kindly created by [data354](https://data354.com/en/).
+
+> This is not a production-ready model since it hasn't been trained for many epochs. It is for illustration purposes only.
+
+## Example Payload
+
+Here is an example payload you can use to test model inference.
+
+```json
+{
+    "inputs": [
+        {
+            "name": "input-0",
+            "shape": [1],
+            "datatype": "BYTES",
+            "parameters": null,
+            "data": [
+                "i tɔgɔ bi cogodɔ"
+            ]
+        }
+    ]
+}
+```


### PR DESCRIPTION
## Overview

This PR adds model cards to some of the examples to provide more information about each model (like the data it was trained on, how to request inference and how to interpret the response).

These can be used to populate Use Case cards in Highwind or to provide details for deployments on Highwind Deck.

## Changes
- Added model cards at `<example>/deployment/model_card.md`