### PR TITLE
Update PowerShell API inference command for v5 and above.

### DIFF
--- a/california-housing/deployment/README.md
+++ b/california-housing/deployment/README.md
@@ -49,7 +49,7 @@ This step builds the Kserve predictor image that contains your model.
 
     ```PowerShell
     $json = Get-Content -Raw -Path ./input.json
-    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
+    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body ([System.Text.Encoding]::UTF8.GetBytes($json))
     $responseObject = $response.Content | ConvertFrom-Json
     $responseObject | ConvertTo-Json -Depth 10
     ```

--- a/helsinki-nlp-opus-mt-en-fr/deployment/README.md
+++ b/helsinki-nlp-opus-mt-en-fr/deployment/README.md
@@ -49,5 +49,7 @@ This step builds the Kserve predictor image that contains your model.
 
     ```PowerShell
     $json = Get-Content -Raw -Path ./input.json
-    Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
+    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body ([System.Text.Encoding]::UTF8.GetBytes($json))
+    $responseObject = $response.Content | ConvertFrom-Json
+    $responseObject | ConvertTo-Json -Depth 10
     ```

--- a/iris-classification/deployment/README.md
+++ b/iris-classification/deployment/README.md
@@ -49,7 +49,7 @@ This step builds the Kserve predictor image that contains your model.
 
     ```PowerShell
     $json = Get-Content -Raw -Path ./input.json
-    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
+    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body ([System.Text.Encoding]::UTF8.GetBytes($json))
     $responseObject = $response.Content | ConvertFrom-Json
     $responseObject | ConvertTo-Json -Depth 10
     ```

--- a/machine-translation/deployment/README.md
+++ b/machine-translation/deployment/README.md
@@ -45,8 +45,7 @@ This folder contains the resources required for deploying the trained model onto
 
     ```PowerShell
     $json = Get-Content -Raw -Path ./input.json
-    Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
-    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
+    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body ([System.Text.Encoding]::UTF8.GetBytes($json))
     $responseObject = $response.Content | ConvertFrom-Json
     $responseObject | ConvertTo-Json -Depth 10
     ```

--- a/translate-dyu-fr-hugging-face/deployment/README.md
+++ b/translate-dyu-fr-hugging-face/deployment/README.md
@@ -49,7 +49,7 @@ This step builds the Kserve predictor image that contains your model.
 
     ```PowerShell
     $json = Get-Content -Raw -Path ./input.json
-    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
+    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body ([System.Text.Encoding]::UTF8.GetBytes($json))
     $responseObject = $response.Content | ConvertFrom-Json
     $responseObject | ConvertTo-Json -Depth 10
     ```

--- a/translate-dyu-fr-joyenmt/deployment/README.md
+++ b/translate-dyu-fr-joyenmt/deployment/README.md
@@ -60,5 +60,7 @@ This step builds the Kserve predictor image that contains your model.
 
     ```PowerShell
     $json = Get-Content -Raw -Path ./input.json
-    Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body $json
+    $response = Invoke-WebRequest -Uri http://localhost:8080/v2/models/model/infer -Method Post -ContentType 'application/json' -Body ([System.Text.Encoding]::UTF8.GetBytes($json))
+    $responseObject = $response.Content | ConvertFrom-Json
+    $responseObject | ConvertTo-Json -Depth 10
     ```


### PR DESCRIPTION
- The previous PS command was not compatible with PowerShell v5 because it could not parse the JSON body.
- Updated PS command in all deployment README files to be compatible with v5 and above.