### PR TITLE
Add Gradio app for KNN recommender

### DIFF
--- a/knn-banking-product-recommender/.gitignore
+++ b/knn-banking-product-recommender/.gitignore
@@ -1,1 +1,1 @@
-.train.venv/
+**.venv/

--- a/knn-banking-product-recommender/deployment/README.md
+++ b/knn-banking-product-recommender/deployment/README.md
@@ -99,12 +99,15 @@ The Gradio app is a simple graphical interface for testing the model. It is not 
 
 ### Deploying the app on Highwind
 
+1. Create a new Highwind Use Case
+    1. On Highwind, create a new Use Case without adding any assets to it
+
 1. Create a Gradio Asset on Highwind
-    1. On Highwind, create a new Asset and select "Gradio App" as the Asset type.
-    2. Upload the `demo.py` to this asset.
+    1. Update the `USE_CASE_ID` variable in the `demo.py` file to the ID of the Use Case you created in the previous step
+    2. On Highwind, create a new Asset and select "Gradio App" as the Asset type.
+    3. Upload the `demo.py` to this asset.
         > ⚠️ Warning: Remember to comment the `demo.launch()` line of the `demo.py` before uploading to Highwind.
 
-1. Create a new Highwind Use Case
-    1. On Highwind, create a new Use Case
-    2. Add the Asset that you created to the Use Case
-    3. When viewing the Use Case, the Gradio App should now be visible
+1. Link the Gradio Asset to the Use Case
+    1. Add the Asset that you created to the Use Case
+    2. When viewing the Use Case, the Gradio App should now be visible

--- a/knn-banking-product-recommender/deployment/README.md
+++ b/knn-banking-product-recommender/deployment/README.md
@@ -2,7 +2,7 @@
 
 This folder contains the resources required for deploying the trained model onto Highwind.
 
-## Usage
+## Predictor
 
 > All commands below are run from this directory.
 
@@ -66,3 +66,45 @@ This step builds the Kserve predictor image that contains your model.
     $responseObject = $response.Content | ConvertFrom-Json
     $responseObject | ConvertTo-Json -Depth 10
     ```
+
+## Gradio App
+
+The Gradio app is a simple graphical interface for testing the model. It is not required for deployment, but it can be added to the Highwind Use Case to allow for easier testing.
+
+### Local testing
+
+> All commands below are run from this directory.
+> You can also test how the app works without running inference on the deployed Highwind Use Case by setting function of the function of the `submit_button.click` to `get_mock_product_recommendation` instead of `get_product_recommendation` (set this in `demo.py`).
+
+1. Install the dependencies in a virtual environment
+
+    > This section requires Python 3.12 or higher
+
+    ```bash
+    python -m venv .gradio.venv && source .gradio.venv/bin/activate
+    pip install -r gradio.requirements.txt
+    ```
+
+1. Uncomment the last line of the `demo.py` file so that the app launches locally when following the next step.
+
+    > ⚠️ Warning: Do not forget to comment the `demo.launch()` line of the `demo.py` before deploying to Highwind. This step is only for local testing!
+
+1. Run the app (from the virtual environment)
+
+    ```bash
+    python demo.py
+    ```
+
+1. Open your browser and navigate to [`http://127.0.0.1:7860`](http://127.0.0.1:7860) to access the app.
+
+### Deploying the app on Highwind
+
+1. Create a Gradio Asset on Highwind
+    1. On Highwind, create a new Asset and select "Gradio App" as the Asset type.
+    2. Upload the `demo.py` to this asset.
+        > ⚠️ Warning: Remember to comment the `demo.launch()` line of the `demo.py` before uploading to Highwind.
+
+1. Create a new Highwind Use Case
+    1. On Highwind, create a new Use Case
+    2. Add the Asset that you created to the Use Case
+    3. When viewing the Use Case, the Gradio App should now be visible

--- a/knn-banking-product-recommender/deployment/demo.py
+++ b/knn-banking-product-recommender/deployment/demo.py
@@ -85,10 +85,10 @@ with gr.Blocks() as demo:
     )
     submit_button = gr.Button("Submit", variant="primary")
     submit_button.click(
-        fn=get_mock_product_recommendation,  # Choose mock or real inference function
+        fn=get_product_recommendation,  # Choose mock or real inference function
         inputs=[user_id],
         outputs=[output],
     )
 
 # For local testing
-demo.launch()
+# demo.launch()

--- a/knn-banking-product-recommender/deployment/demo.py
+++ b/knn-banking-product-recommender/deployment/demo.py
@@ -1,0 +1,94 @@
+from typing import Dict
+
+import gradio as gr
+import highwind
+
+# Replace this with the unique id of your UseCase on Highwind
+# This can be found by viewing the UseCase on the Highwind frontend and extracting it from the URL:
+# https://frontend.dev.highwind.cloud/use_cases/{{use-case-id-to-copy}}
+USE_CASE_ID: str = "..."
+
+
+def get_mock_product_recommendation(
+    user_id: str,
+    request: gr.Request,
+) -> str:
+    """
+    Mock version of the get_product_recommendation function.
+    Can be used for simple testing where you don't want to run inference on Highwind.
+    """
+    recommended_items: list[str] = [
+        "Credit Card",
+        "Personal Loan",
+        "Investment Account",
+    ]
+
+    # Format the output as a Markdown bullet point list
+    formatted_output: str = f"- {'\n- '.join(recommended_items)}"
+    return formatted_output
+
+
+def get_product_recommendation(
+    user_id: str,
+    request: gr.Request,
+) -> str:
+    """
+    This function takes a user ID and returns a list of product recommendations for them.
+
+    Args:
+        user_id (str): The ID of the user.
+        request (gr.Request): The request object.
+
+    Returns:
+        str: The list of product recommendations as a Markdown bullet point list.
+    """
+    # Initialize Highwind to work with this Gradio App.
+    highwind.GradioApp.setup_with_request(request)
+    use_case: highwind.UseCase = highwind.UseCase(id=USE_CASE_ID)
+
+    # Construct inference payload
+    inference_payload: Dict = {
+        "inputs": [
+            {
+                "name": "input-0",
+                "shape": [1],
+                "datatype": "INT32",
+                "data": [int(user_id)],
+            }
+        ]
+    }
+
+    # Run inference
+    inference_result: Dict = use_case.run_inference(inference_payload)
+    recommended_items: list[str] = inference_result["outputs"][0]["data"]
+
+    # Format the output as a Markdown bullet point list
+    formatted_output: str = f"- {'\n- '.join(recommended_items)}"
+    return formatted_output
+
+
+# The Gradio App, called demo
+with gr.Blocks() as demo:
+    gr.Markdown("<center><h1>Banking Product Recommender</h1></center>")
+    gr.Markdown(
+        "<center>This app looks up pre-computed, personalised banking products for a user with a given user ID.</center>"
+    )
+    user_id = gr.Textbox(
+        label="User ID",
+        placeholder="123456",
+        info="The user who you want product recommendations for",
+    )
+    output = gr.Textbox(
+        label="Product Recommendations",
+        lines=5,
+        info="The products recommended for the user",
+    )
+    submit_button = gr.Button("Submit", variant="primary")
+    submit_button.click(
+        fn=get_mock_product_recommendation,  # Choose mock or real inference function
+        inputs=[user_id],
+        outputs=[output],
+    )
+
+# For local testing
+demo.launch()

--- a/knn-banking-product-recommender/deployment/gradio.requirements.txt
+++ b/knn-banking-product-recommender/deployment/gradio.requirements.txt
@@ -1,0 +1,3 @@
+# Python 3.12
+gradio>=4.31.4
+highwind==1.0.0


### PR DESCRIPTION
## Overview

This PR adds a simple Gradio app for the KNN recommender. It looks like this:

<img src="https://github.com/user-attachments/assets/82e3def8-177b-4b76-aafe-20171c73a077" width="500"/>


## Changes

- Added Gradio app
- Added Gradio app requirements
- Updated deployment README with instructions on how to test and deploy the Gradio app

## To test

Please follow the testing instructions (locally and on HW) in `knn-banking-product-recommender/deployment/README.md`